### PR TITLE
Fixed wrong Amperage unit (current).

### DIFF
--- a/src/session/battery.rs
+++ b/src/session/battery.rs
@@ -37,7 +37,7 @@ impl TryFrom<Payload> for BatteryInfo {
       BatteryInfo {
         capacity: payload.pop_u16()?,
         percent: payload.pop_u16()?,
-        current: payload.pop_i16()? as f32 / 10.0,
+        current: payload.pop_i16()? as f32 / 100.0,
         voltage: payload.pop_u16()? as f32 / 100.0,
         temperature_1: payload.pad_byte()?,
         temperature_2: payload.pad_byte()?,
@@ -84,7 +84,7 @@ impl MiSession {
     let mut payload = self.read(2).await?;
     payload.pop_head()?;
 
-    let amperage = payload.pop_i16()? as f32 / 10.0;
+    let amperage = payload.pop_i16()? as f32 / 100.0;
 
     Ok(amperage)
   }


### PR DESCRIPTION
According to the scooter protocol documentation provided by CamiAlfa, found in the documentation folder, the battery current is specified in Amps and should be divided by 100.

https://github.com/macbury/m365/blob/cc61bfda346d9747c7f1769e3590d2967b5cdc2a/doc/protocol.md?plain=1#L240

However, you are dividing it by 10 in your code.

https://github.com/macbury/m365/blob/cc61bfda346d9747c7f1769e3590d2967b5cdc2a/src/session/battery.rs#L40

https://github.com/macbury/m365/blob/cc61bfda346d9747c7f1769e3590d2967b5cdc2a/src/session/battery.rs#L87

This causes your test to fail, as it expects 0.01 but receives 0.1.

https://github.com/macbury/m365/blob/cc61bfda346d9747c7f1769e3590d2967b5cdc2a/tests/motor_info_test.rs#L33

Apart from that, I want to congratulate you on the excellent work you did implementing the protocol in Rust. It is very useful.